### PR TITLE
Add price rules and price rule discount codes resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Currently a Work in Progress**
 
-This package allows Elixir developers to easily access the admin Shopify API. 
+This package allows Elixir developers to easily access the admin Shopify API.
 
 ## Installation
 
@@ -182,6 +182,8 @@ with a single struct, or list of structs of the resource or resources requested.
 - Option
 - Order (find, all, create, update, delete, count)
 - PaymentDetails
+- PriceRule (find, all, create, update, delete)
+- PriceRule.DiscountCode (find, all, create, update, delete)
 - Product (find, all, create, update, delete, count)
 - RecurringApplicationCharge (find, all, create, activate, delete)
 - ScriptTag (find, all, create, count, delete)

--- a/lib/shopify/resource.ex
+++ b/lib/shopify/resource.ex
@@ -1,7 +1,7 @@
 defmodule Shopify.Resource do
   defmacro __using__(options) do
     import_functions = options[:import] || []
-    
+
     quote bind_quoted: [import_functions: import_functions] do
       alias Shopify.{Client, Request, Session}
 
@@ -15,7 +15,7 @@ defmodule Shopify.Resource do
           - session: A `%Shopify.Session{}` struct.
           - id: The id of the resource.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.find(id)
             {:ok, %Shopify.Response{}}
@@ -36,7 +36,7 @@ defmodule Shopify.Resource do
         ## Parameters
           - session: A `%Shopify.Session{}` struct.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.all
             {:ok, %Shopify.Response{}}
@@ -57,7 +57,7 @@ defmodule Shopify.Resource do
         ## Parameters
           - session: A `%Shopify.Session{}` struct.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.count
             {:ok, %Shopify.Response{}}
@@ -78,7 +78,7 @@ defmodule Shopify.Resource do
         ## Parameters
           - session: A `%Shopify.Session{}` struct.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.search
             {:ok, %Shopify.Response{}}
@@ -100,7 +100,7 @@ defmodule Shopify.Resource do
         ## Parameters
           - session: A `%Shopify.Session{}` struct.
           - new_resource: A struct of the resource being created.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.create(%Shopify.Product{})
             {:ok, %Shopify.Response{}}
@@ -124,7 +124,7 @@ defmodule Shopify.Resource do
           - session: A `%Shopify.Session{}` struct.
           - id: The id of the resource.
           - updated_resource: A struct of the resource being updated.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.update(id, %Shopify.Product{})
             {:ok, %Shopify.Response{}}
@@ -146,7 +146,7 @@ defmodule Shopify.Resource do
         ## Parameters
           - session: A `%Shopify.Session{}` struct.
           - id: The id of the resource.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Product.delete(id)
             {:ok, %Shopify.Response{}}

--- a/lib/shopify/resources/price_rule.ex
+++ b/lib/shopify/resources/price_rule.ex
@@ -1,0 +1,49 @@
+defmodule Shopify.PriceRule do
+  @derive [Poison.Encoder]
+  @singular "price_rule"
+  @plural "price_rules"
+
+  use Shopify.Resource, import: [
+    :find,
+    :all,
+    :create,
+    :update,
+    :delete
+  ]
+
+  defstruct [
+    :id,
+    :value_type,
+    :value,
+    :customer_selection,
+    :target_type,
+    :target_selection,
+    :allocation_method,
+    :once_per_customer,
+    :usage_limit,
+    :starts_at,
+    :ends_at,
+    :created_at,
+    :updated_at,
+    :prerequisite_subtotal_range,
+    :prerequisite_shipping_price_range,
+    :title,
+    :entitled_product_ids,
+    :entitled_variant_ids,
+    :entitled_collection_ids,
+    :entitled_country_ids,
+    :prerequisite_saved_search_ids,
+    :discount_codes
+  ]
+
+  @doc false
+  def empty_resource do
+    %Shopify.PriceRule{}
+  end
+
+  @doc false
+  def find_url(id), do: @plural <>  "/#{id}.json"
+
+  @doc false
+  def all_url, do: @plural <> ".json"
+end

--- a/lib/shopify/resources/price_rule/discount_code.ex
+++ b/lib/shopify/resources/price_rule/discount_code.ex
@@ -1,0 +1,36 @@
+defmodule Shopify.PriceRule.DiscountCode do
+  @derive [Poison.Encoder]
+  @singular "discount_code"
+  @plural "discount_codes"
+
+  use Shopify.NestedResource, import: [
+    :find,
+    :all,
+    :create,
+    :update,
+    :delete
+  ]
+
+  defstruct [
+    :id,
+    :price_rule_id,
+    :code,
+    :usage_count,
+    :created_at,
+    :updated_at
+  ]
+
+  @doc false
+  def empty_resource do
+    %Shopify.PriceRule.DiscountCode{}
+  end
+
+  @doc false
+  def find_url(price_rule_id, id), do: url_prefix(price_rule_id) <>  @plural <>  "/#{id}.json"
+
+  @doc false
+  def all_url(price_rule_id), do: url_prefix(price_rule_id) <> @plural <> ".json"
+
+  @doc false
+  defp url_prefix(price_rule_id), do: "price_rules/#{price_rule_id}/"
+end

--- a/test/fixtures/price_rules.json
+++ b/test/fixtures/price_rules.json
@@ -1,0 +1,56 @@
+{
+    "price_rules": [
+        {
+            "id": 1,
+            "value_type": "fixed_amount",
+            "value": "-500.0",
+            "customer_selection": "prerequisite",
+            "target_type": "line_item",
+            "target_selection": "entitled",
+            "allocation_method": "across",
+            "once_per_customer": false,
+            "usage_limit": 1,
+            "starts_at": "2017-12-19T02:17:08-05:00",
+            "ends_at": null,
+            "created_at": "2017-12-19T02:17:08-05:00",
+            "updated_at": "2017-12-19T02:17:08-05:00",
+            "entitled_product_ids": [
+                1
+            ],
+            "entitled_variant_ids": [],
+            "entitled_collection_ids": [],
+            "entitled_country_ids": [],
+            "prerequisite_saved_search_ids": [
+                1
+            ],
+            "prerequisite_subtotal_range": null,
+            "prerequisite_shipping_price_range": null,
+            "title": "74NSJ3SK08M0"
+        },
+        {
+            "id": 2,
+            "value_type": "percentage",
+            "value": "-10.0",
+            "customer_selection": "all",
+            "target_type": "line_item",
+            "target_selection": "all",
+            "allocation_method": "across",
+            "once_per_customer": false,
+            "usage_limit": null,
+            "starts_at": "2017-12-19T02:13:17-05:00",
+            "ends_at": null,
+            "created_at": "2017-12-19T02:13:18-05:00",
+            "updated_at": "2017-12-19T02:13:18-05:00",
+            "entitled_product_ids": [],
+            "entitled_variant_ids": [],
+            "entitled_collection_ids": [],
+            "entitled_country_ids": [],
+            "prerequisite_saved_search_ids": [],
+            "prerequisite_subtotal_range": {
+                "greater_than_or_equal_to": "5000.0"
+            },
+            "prerequisite_shipping_price_range": null,
+            "title": "2M42ZNSW82TA"
+        }
+    ]
+}

--- a/test/fixtures/price_rules/1.json
+++ b/test/fixtures/price_rules/1.json
@@ -1,0 +1,29 @@
+{
+    "price_rule": {
+        "id": 1,
+        "value_type": "fixed_amount",
+        "value": "-500.0",
+        "customer_selection": "prerequisite",
+        "target_type": "line_item",
+        "target_selection": "entitled",
+        "allocation_method": "across",
+        "once_per_customer": false,
+        "usage_limit": 1,
+        "starts_at": "2017-12-19T02:17:08-05:00",
+        "ends_at": null,
+        "created_at": "2017-12-19T02:17:08-05:00",
+        "updated_at": "2017-12-19T02:17:08-05:00",
+        "entitled_product_ids": [
+            1
+        ],
+        "entitled_variant_ids": [],
+        "entitled_collection_ids": [],
+        "entitled_country_ids": [],
+        "prerequisite_saved_search_ids": [
+            1
+        ],
+        "prerequisite_subtotal_range": null,
+        "prerequisite_shipping_price_range": null,
+        "title": "74NSJ3SK08M0"
+    }
+}

--- a/test/fixtures/price_rules/1/discount_codes.json
+++ b/test/fixtures/price_rules/1/discount_codes.json
@@ -1,0 +1,28 @@
+{
+    "discount_codes": [
+        {
+            "id": 1,
+            "price_rule_id": 1,
+            "code": "MySecondCode",
+            "usage_count": 0,
+            "created_at": "2017-12-19T04:32:55-05:00",
+            "updated_at": "2017-12-19T04:32:55-05:00"
+        },
+        {
+            "id": 2,
+            "price_rule_id": 1,
+            "code": "MyFirstCode",
+            "usage_count": 0,
+            "created_at": "2017-12-19T04:29:02-05:00",
+            "updated_at": "2017-12-19T04:29:02-05:00"
+        },
+        {
+            "id": 3,
+            "price_rule_id": 1,
+            "code": "LeCodeDe3",
+            "usage_count": 3,
+            "created_at": "2017-12-19T03:33:33-03:33",
+            "updated_at": "2017-12-19T04:33:33-03:33"
+        }
+    ]
+}

--- a/test/fixtures/price_rules/1/discount_codes/1.json
+++ b/test/fixtures/price_rules/1/discount_codes/1.json
@@ -1,0 +1,10 @@
+{
+  "discount_code": {
+      "id": 1,
+      "price_rule_id": 1,
+      "code": "MySecondCode",
+      "usage_count": 0,
+      "created_at": "2017-12-19T04:32:55-05:00",
+      "updated_at": "2017-12-19T04:32:55-05:00"
+  }
+}

--- a/test/price_rule/discount_code_test.exs
+++ b/test/price_rule/discount_code_test.exs
@@ -1,0 +1,50 @@
+defmodule Shopify.PriceRule.DiscountCodeTest do
+  use ExUnit.Case, async: true
+
+  alias Shopify.{
+    PriceRule.DiscountCode,
+    PriceRule
+  }
+
+  @fixtures_path "../test/fixtures/price_rules/1/"
+
+  test "client can request all price rules" do
+      assert {:ok, response} = Shopify.session |> DiscountCode.all(1)
+      assert %Shopify.Response{} = response
+      assert 200 == response.code
+      fixture = Fixture.load(@fixtures_path <> "discount_codes.json", "discount_codes", [DiscountCode.empty_resource()])
+      assert fixture == response.data
+  end
+
+  test "client can request a single price rule" do
+    assert {:ok, response} = Shopify.session |> DiscountCode.find(1, 1)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    fixture = Fixture.load(@fixtures_path <> "discount_codes/1.json", "discount_code", DiscountCode.empty_resource())
+    assert fixture == response.data
+  end
+
+  test "client can request to create a price_rule" do
+    fixture = Fixture.load(@fixtures_path <> "discount_codes/1.json", "discount_code", DiscountCode.empty_resource())
+    assert {:ok, response} = Shopify.session |> DiscountCode.create(1, fixture)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    fixture = Fixture.load(@fixtures_path <> "discount_codes/1.json", "discount_code", DiscountCode.empty_resource())
+    assert fixture == response.data
+  end
+
+  test "client can request to update a price_rule" do
+    assert {:ok, response} = Shopify.session |> DiscountCode.find(1, 1)
+    assert "MySecondCode" == response.data.code
+    update = %{response.data | code: "123Code"}
+    assert {:ok, response} = Shopify.session |> DiscountCode.update(1, 1, update)
+    assert "123Code" == response.data.code
+  end
+
+  test "client can request to delete a price rule" do
+    assert {:ok, response} = Shopify.session |> DiscountCode.delete(1, 1)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    assert nil == response.data
+  end
+end

--- a/test/price_rule_test.exs
+++ b/test/price_rule_test.exs
@@ -1,0 +1,45 @@
+defmodule Shopify.PriceRuleTest do
+  use ExUnit.Case, async: true
+
+  alias Shopify.PriceRule
+
+  test "client can request all price rules" do
+      assert {:ok, response} = Shopify.session |> PriceRule.all()
+      assert %Shopify.Response{} = response
+      assert 200 == response.code
+      fixture = Fixture.load("../test/fixtures/price_rules.json", "price_rules", [PriceRule.empty_resource()])
+      assert fixture == response.data
+  end
+
+  test "client can request a single price rule" do
+    assert {:ok, response} = Shopify.session |> PriceRule.find(1)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    fixture = Fixture.load("../test/fixtures/price_rules/1.json", "price_rule", PriceRule.empty_resource())
+    assert fixture == response.data
+  end
+
+  test "client can request to create a price_rule" do
+    fixture = Fixture.load("../test/fixtures/price_rules/1.json", "price_rule", PriceRule.empty_resource())
+    assert {:ok, response} = Shopify.session |> PriceRule.create(fixture)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    fixture = Fixture.load("../test/fixtures/price_rules/1.json", "price_rule", PriceRule.empty_resource())
+    assert fixture == response.data
+  end
+
+  test "client can request to update a price_rule" do
+    assert {:ok, response} = Shopify.session |> PriceRule.find(1)
+    assert "74NSJ3SK08M0" == response.data.title
+    update = %{response.data | title: "Blehp"}
+    assert {:ok, response} = Shopify.session |> PriceRule.update(1, update)
+    assert "Blehp" == response.data.title
+  end
+
+  test "client can request to delete a price rule" do
+    assert {:ok, response} = Shopify.session |> PriceRule.delete(1)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    assert nil == response.data
+  end
+end


### PR DESCRIPTION
I had to namespace the discount codes, since there is already a discount code resource.
Made me thing it might be nice to move all the nested resources (for example transaction) into folders to reflect how they are nested (resources/order/transaction.ex).

* [discount codes documentation](https://help.shopify.com/api/reference/discountcode)
* [price rules documentation](https://help.shopify.com/api/reference/pricerule)

EDIT: I am planning on implementing the batch endpoint as well, but I started with the basic ones, since those are the ones I am using right now 🙇 