### PR TITLE
Make adapter configurable and make mock adapter public

### DIFF
--- a/lib/shopify/client.ex
+++ b/lib/shopify/client.ex
@@ -1,13 +1,13 @@
 defmodule Shopify.Client do
   @moduledoc false
 
-  @adapter Shopify.Config.get(:client_adapter) || Shopify.Adapters.HTTP
+  alias Shopify.Config
 
-  def get(request), do: @adapter.get(request)
+  def get(request), do: Config.client_adapter.get(request)
 
-  def post(request), do: @adapter.post(request)
+  def post(request), do: Config.client_adapter.post(request)
 
-  def put(request), do: @adapter.put(request)
+  def put(request), do: Config.client_adapter.put(request)
 
-  def delete(request), do: @adapter.delete(request)
+  def delete(request), do: Config.client_adapter.delete(request)
 end

--- a/lib/shopify/config.ex
+++ b/lib/shopify/config.ex
@@ -1,9 +1,11 @@
 defmodule Shopify.Config do
   @moduledoc false
-  
+
   def get(name, default \\ nil) do
     Application.get_env(:shopify, name, default)
   end
+
+  def client_adapter, do: get(:client_adapter, Shopify.Adapters.HTTP)
 
   def shop_name, do: get(:shop_name)
 
@@ -12,4 +14,8 @@ defmodule Shopify.Config do
   def password, do: get(:password)
 
   def version, do: Mix.Project.config[:version]
+
+  def fixtures_path do
+    get(:fixtures_path) || Path.expand("../../test/fixtures/", __DIR__)
+  end
 end

--- a/test/adapters/mock_test.exs
+++ b/test/adapters/mock_test.exs
@@ -1,0 +1,16 @@
+defmodule Shopify.Adapters.Mocktest do
+  use ExUnit.Case, async: true
+
+  alias Shopify.{Webhook, Request, Adapters.Mock}
+
+  test "it puts an id for created resources" do
+    body = "{\"webhook\": {\"address\": \"http://www.yoloship.it/webhook\"}}"
+
+    {:ok, %{data: resource}} = Shopify.session
+      |> Request.new(Webhook.all_url(), %{}, Webhook.singular_resource(), body)
+      |> Mock.post
+
+    assert resource.id != nil
+  end
+
+end


### PR DESCRIPTION
When I was writing tests for a project using this library, I tried to wrap my head around how to mock all the shopify requests. I skimmed through the code and realized the library already has `Adapters.Mock` implemented, but it is not accessible outside of internal testing.

As you can see, this is pure code, I haven't updated the README. If you are interested in this feature, let me know and I will add a README entry on how to use the mock adapter in testing.

EDIT: I also needed a created resource to have an ID, because I was testing it in a context where I had to save the shopify id to database and I needed it to be mandatory, so I put that in this PR as well. I think it is reasonable to have created resources with an ID :+1: 