### PR TITLE
Make nested and non nested resources mixable

### DIFF
--- a/lib/shopify/nested_resource.ex
+++ b/lib/shopify/nested_resource.ex
@@ -1,7 +1,7 @@
 defmodule Shopify.NestedResource do
   defmacro __using__(options) do
     import_functions = options[:import] || []
-    
+
     quote bind_quoted: [import_functions: import_functions] do
       alias Shopify.{Client, Request, Session}
 
@@ -16,12 +16,12 @@ defmodule Shopify.NestedResource do
           - top_id: The id of the top-level resource.
           - nest_id: The id of the nest-level resource.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Transaction.find(order_id, transaction_id)
             {:ok, %Shopify.Response{}}
         """
-        def find(%Session{} = session, top_id, nest_id, params \\ %{}) do
+        def find(%Session{} = session, top_id, nest_id, params \\ %{}) when not is_map(nest_id) do
           session
             |> Request.new(find_url(top_id, nest_id), params, singular_resource())
             |> Client.get
@@ -38,12 +38,12 @@ defmodule Shopify.NestedResource do
           - session: A `%Shopify.Session{}` struct.
           - top_id: The id of the top-level resource.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Transaction.all(order_id)
             {:ok, %Shopify.Response{}}
         """
-        def all(%Session{} = session, top_id, params \\ %{}) do
+        def all(%Session{} = session, top_id, params \\ %{}) when not is_map(top_id) do
           session
             |> Request.new(all_url(top_id), params, plural_resource())
             |> Client.get
@@ -60,12 +60,12 @@ defmodule Shopify.NestedResource do
           - session: A `%Shopify.Session{}` struct.
           - top_id: The id of the top-level resource.
           - params: Any additional query params.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Transaction.count(order_id)
             {:ok, %Shopify.Response{}}
         """
-        def count(%Session{} = session, top_id, params \\ %{}) do
+        def count(%Session{} = session, top_id, params \\ %{}) when not is_map(top_id) do
           session
             |> Request.new(count_url(top_id), params, nil)
             |> Client.get
@@ -82,7 +82,7 @@ defmodule Shopify.NestedResource do
           - session: A `%Shopify.Session{}` struct.
           - top_id: The id of the top-level resource.
           - new_resource: A struct of the resource being created.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.Transaction.create(order_id)
             {:ok, %Shopify.Response{}}
@@ -106,7 +106,7 @@ defmodule Shopify.NestedResource do
           - top_id: The id of the top-level resource.
           - nest_id: The id of the nested-level resource.
           - updated_resource: A struct of the resource being updated.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.CustomerAddress.update(customer_id, address_id)
             {:ok, %Shopify.Response{}}
@@ -129,7 +129,7 @@ defmodule Shopify.NestedResource do
           - session: A `%Shopify.Session{}` struct.
           - top_id: The id of the top-level resource.
           - nest_id: The id of the nested resource.
-          
+
         ## Examples
             iex> Shopify.session |> Shopify.CustomerAddress.delete(customer_id, address_id)
             {:ok, %Shopify.Response{}}

--- a/lib/shopify/resources/collection_listing.ex
+++ b/lib/shopify/resources/collection_listing.ex
@@ -30,7 +30,7 @@ defmodule Shopify.CollectionListing do
   end
 
   @doc false
-  def find_url(top_id, nest_id) do 
+  def find_url(top_id, nest_id) do
     "applications/#{top_id}/" <> @plural <>  "/#{nest_id}.json"
   end
 

--- a/lib/shopify/resources/customer_address.ex
+++ b/lib/shopify/resources/customer_address.ex
@@ -37,7 +37,7 @@ defmodule Shopify.CustomerAddress do
   end
 
   @doc false
-  def find_url(top_id, nest_id) do 
+  def find_url(top_id, nest_id) do
     "customers/#{top_id}/" <> @plural <>  "/#{nest_id}.json"
   end
 

--- a/lib/shopify/resources/image.ex
+++ b/lib/shopify/resources/image.ex
@@ -32,7 +32,7 @@ defmodule Shopify.Image do
   end
 
   @doc false
-  def find_url(top_id, nest_id) do 
+  def find_url(top_id, nest_id) do
     "products/#{top_id}/" <> @plural <>  "/#{nest_id}.json"
   end
 

--- a/lib/shopify/resources/refund.ex
+++ b/lib/shopify/resources/refund.ex
@@ -1,6 +1,6 @@
 defmodule Shopify.Refund do
   @moduledoc false
-  
+
   @derive [Poison.Encoder]
   @singular "refund"
   @plural "refunds"
@@ -32,7 +32,7 @@ defmodule Shopify.Refund do
   end
 
   @doc false
-  def find_url(top_id, nest_id) do 
+  def find_url(top_id, nest_id) do
     "orders/#{top_id}/" <> @plural <>  "/#{nest_id}.json"
   end
 

--- a/lib/shopify/resources/transaction.ex
+++ b/lib/shopify/resources/transaction.ex
@@ -42,7 +42,7 @@ defmodule Shopify.Transaction do
   end
 
   @doc false
-  def find_url(top_id, nest_id) do 
+  def find_url(top_id, nest_id) do
     "orders/#{top_id}/" <> @plural <>  "/#{nest_id}.json"
   end
 

--- a/lib/shopify/resources/usage_charge.ex
+++ b/lib/shopify/resources/usage_charge.ex
@@ -2,7 +2,7 @@ defmodule Shopify.UsageCharge do
   @derive [Poison.Encoder]
   @singular "usage_charge"
   @plural "usage_charges"
-  
+
   use Shopify.NestedResource, import: [
     :find,
     :all,
@@ -28,7 +28,7 @@ defmodule Shopify.UsageCharge do
   end
 
   @doc false
-  def find_url(top_id, nest_id) do 
+  def find_url(top_id, nest_id) do
     "recurring_application_charges/#{top_id}/" <> @plural <>  "/#{nest_id}.json"
   end
 

--- a/lib/shopify/resources/variant.ex
+++ b/lib/shopify/resources/variant.ex
@@ -1,6 +1,6 @@
 defmodule Shopify.Variant do
   @moduledoc false
-  
+
   @derive [Poison.Encoder]
 
   defstruct [


### PR DESCRIPTION
Some Shopify API resources used nested endpoints like `products/123/variants` for some actions and non-nested for others `variants/1245`.

With these changes, it is possible to use the `NestedResource` together with the `Resource` module

```elixir
defmodule Shopify.SomeResource do
  use Shopify.NestedResource, import: [
    :all,
    :create,
    :count
  ]

  use Shopify.Resource, import: [
    :find
  ]

  def find_url(id), do: @plural <> "/#{id}"

  def find_url(top_id, id), do: "top_resources/#{top_id}/" <> @plural <> "/some_resources/#{id}"

  # ...
end
```