### PR TITLE
Add phone to customer resource

### DIFF
--- a/lib/shopify/resources/customer.ex
+++ b/lib/shopify/resources/customer.ex
@@ -25,6 +25,7 @@ defmodule Shopify.Customer do
     :created_at,
     :default_address,
     :email,
+    :phone,
     :first_name,
     :id,
     :multipass_identifier,


### PR DESCRIPTION
The customer object in Shopify also has the phone attribute

https://help.shopify.com/api/reference/customer#properties