### PR TITLE
Handle empty Shopify response.

### DIFF
--- a/lib/shopify/response.ex
+++ b/lib/shopify/response.ex
@@ -16,9 +16,7 @@ defmodule Shopify.Response do
     {:error, %Response{code: code, data: error |> parse_json(body)}}
   end
 
-  defp parse_json(_, nil) do
-    nil
-  end
+  defp parse_json(_, body) when is_nil(body) or body == "", do: nil
 
   defp parse_json(resource, body) do
     case Poison.decode(body, as: resource) do


### PR DESCRIPTION
It appears that Shopify responds with an empty body when deleting a `RecurringApplicationCharge`. This commit adds an updated `parse_json/2` function with a guard clause that accounts for this and returns `nil`.

Closes #24