### PR TITLE
Add transactions to order resource

### DIFF
--- a/lib/shopify/resources/order.ex
+++ b/lib/shopify/resources/order.ex
@@ -88,7 +88,8 @@ defmodule Shopify.Order do
     :contact_email,
     :device_id,
     :source_identifier,
-    :reference
+    :reference,
+    :transactions
   ]
 
   @doc false


### PR DESCRIPTION
When creating an order it is required to add a transaction to the order to get the correct total spent updated for a customer.

On this page: https://help.shopify.com/api/reference/order#create scroll down to `Create a more comprehensive order`

Example use:

```elixir
%Shopify.Order{
       ...
        transactions: [
          %{
            kind: "sale",
            status: "success",
            amount: total_amount
          }
        ]
      ...
      }
```