### PR TITLE
Basic support for query params in mock adapter

### DIFF
--- a/lib/shopify/adapters/base.ex
+++ b/lib/shopify/adapters/base.ex
@@ -1,14 +1,14 @@
 defmodule Shopify.Adapters.Base do
   @moduledoc ~S"""
-  Specification of the..
+  Specification of the adapter used to load resources.
+  Other than from the real Shopify API you could load from fixtures, or from your own mock API.
   """
 
-  @type request :: %Shopify.Request{}
-  @type success :: {:ok, %Shopify.Response{}}
-  @type error :: {:error, %Shopify.Response{}}
+  @type success :: {:ok, Shopify.Response.t()}
+  @type error :: {:error, Shopify.Response.t()}
 
-  @callback get(request) :: success | error
-  @callback put(request) :: success | error
-  @callback post(request) :: success | error
-  @callback delete(request) :: success | error
+  @callback get(Shopify.Request.t()) :: success | error
+  @callback put(Shopify.Request.t()) :: success | error
+  @callback post(Shopify.Request.t()) :: success | error
+  @callback delete(Shopify.Request.t()) :: success | error
 end

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -6,8 +6,16 @@ defmodule Shopify.Adapters.Mock do
   alias Shopify.{
     Request,
     Response,
-    Config
+    Config,
+    Adapters.MockUtils
   }
+
+  def get(%Shopify.Request{query_params: query_params} = request) when not is_nil(query_params) do
+    request
+    |> authorize
+    |> respond
+    |> MockUtils.filter_resources(request)
+  end
 
   def get(request) do
     request
@@ -61,28 +69,9 @@ defmodule Shopify.Adapters.Mock do
 
   def load_resource(%Request{body: body}) do
     case Poison.decode(body) do
-      {:ok, resource} -> resource |> put_id |> Poison.encode()
+      {:ok, resource} -> resource |> MockUtils.put_id() |> Poison.encode()
       {:error, _} -> {:error, nil}
     end
-  end
-
-  defp put_id(raw_resource) do
-    # This works because shopify uses the convention of {"resource_name": resource}
-    # for their JSON REST-API, if they ever decide to put a second value in the top level
-    # it will get a lot harder to know what the resource name is.
-    resource = raw_resource |> Map.values() |> List.first()
-    key = raw_resource |> Map.keys() |> List.first()
-    put_id(key, resource)
-  end
-
-  defp put_id(key, resource) when is_map(resource) do
-    %{key => Map.put_new(resource, "id", 1)}
-  end
-
-  # For all I know, only engagements need this special treatment...
-  defp put_id(key, resources) when is_list(resources) do
-    resources = Enum.map(resources, &Map.put_new(&1, "id", 1))
-    %{key => resources}
   end
 
   def authorize(request) do

--- a/lib/shopify/adapters/mock_utils.ex
+++ b/lib/shopify/adapters/mock_utils.ex
@@ -1,0 +1,77 @@
+defmodule Shopify.Adapters.MockUtils do
+  @moduledoc """
+  Some useful functions to help implementing a mock adapter.
+  """
+
+  @doc """
+  Puts an id into resources, usefull for create options that would otherwise return
+  the resource built from the body without an id.
+  """
+  @spec put_id(map | list(map), integer) :: map
+  def put_id(raw_resource, id \\ 1) do
+    # This works because shopify uses the convention of {"resource_name": resource}
+    # for their JSON REST-API, if they ever decide to put a second value in the top level
+    # it will get a lot harder to know what the resource name is.
+    resource = raw_resource |> Map.values() |> List.first()
+    key = raw_resource |> Map.keys() |> List.first()
+    do_put_id(key, resource, id)
+  end
+
+  defp do_put_id(key, resource, id) when is_map(resource) do
+    %{key => Map.put_new(resource, "id", id)}
+  end
+
+  defp do_put_id(key, resources, id) when is_list(resources) do
+    # For all I know, only engagements need this special treatment...
+    resources = Enum.map(resources, &Map.put_new(&1, "id", id))
+    %{key => resources}
+  end
+
+  @doc """
+  Filter resources if query params given and the resource is a list.
+
+  This is a naive implementation that will fail whenever the query parameter keys do
+  not correspond to the resource keys.
+
+  ## Examples
+      iex> Shopify.Adapters.MockUtils.filter_resources({:ok, %Shopify.Response{data: [%{a: "a"}, %{a: "b"}]}}, %Shopify.Request{query_params: %{a: "a"}})
+      {:ok, %Shopify.Response{code: nil, data: [%{a: "a"}]}}
+
+      iex> Shopify.Adapters.MockUtils.filter_resources({:ok, %Shopify.Response{data: [%{a: "a"}, %{a: "b"}, %{a: "c"}]}}, %Shopify.Request{query_params: %{a: ["a", "b"]}})
+      {:ok, %Shopify.Response{code: nil, data: [%{a: "a"}, %{a: "b"}]}}
+  """
+  @spec filter_resources(
+          Shopify.Adapters.Base.success() | Shopify.Adapters.Base.error(),
+          Shopify.Request.t()
+        ) :: Shopify.Adapters.Base.success() | Shopify.Adapters.Base.error()
+  def filter_resources({:ok, %{data: resources} = resp}, %{query_params: params})
+      when is_list(resources),
+      do: {:ok, %{resp | data: do_filter_resources(resources, params, [])}}
+
+  def filter_resources(resp, _), do: resp
+
+  defp do_filter_resources([], _, filtered), do: filtered
+
+  defp do_filter_resources([resource | rest], params, filtered) do
+    is_in_query =
+      params
+      |> Map.keys()
+      |> Enum.reduce(true, fn key, acc ->
+        acc && resource_in_query(Map.fetch(resource, key), Map.fetch(params, key))
+      end)
+
+    if is_in_query do
+      do_filter_resources(rest, params, filtered ++ [resource])
+    else
+      do_filter_resources(rest, params, filtered)
+    end
+  end
+
+  defp resource_in_query({:ok, resource_val}, {:ok, query_val}) when is_list(query_val),
+    do: resource_val in query_val
+
+  defp resource_in_query({:ok, resource_val}, {:ok, query_val}), do: resource_val == query_val
+
+  # This is the case where the resource does not have that key. Lets just ignore it.
+  defp resource_in_query(:error, _), do: true
+end

--- a/lib/shopify/request.ex
+++ b/lib/shopify/request.ex
@@ -1,6 +1,15 @@
 defmodule Shopify.Request do
   @moduledoc false
 
+  @type t :: %__MODULE__{
+          full_url: String.t(),
+          path: String.t(),
+          resource: map,
+          body: String.t(),
+          headers: list,
+          query_params: map
+        }
+
   @headers [
     "Content-Type": "application/json",
     "Keep-Alive": "timeout=15, max=100",
@@ -8,12 +17,12 @@ defmodule Shopify.Request do
   ]
 
   defstruct [
-    :type,
     :full_url,
     :path,
     :resource,
     :body,
-    :headers
+    :headers,
+    :query_params
   ]
 
   def new(session, path, params \\ %{}, resource, body \\ nil) do
@@ -22,7 +31,8 @@ defmodule Shopify.Request do
       path: path,
       resource: resource,
       body: body,
-      headers: session |> build_headers
+      headers: session |> build_headers,
+      query_params: params
     }
   end
 

--- a/lib/shopify/response.ex
+++ b/lib/shopify/response.ex
@@ -1,6 +1,8 @@
 defmodule Shopify.Response do
   @moduledoc false
 
+  @type t :: %__MODULE__{code: integer, data: map | list(map)}
+
   alias Shopify.Response
 
   defstruct [

--- a/test/adapters/mock_test.exs
+++ b/test/adapters/mock_test.exs
@@ -1,7 +1,12 @@
 defmodule Shopify.Adapters.Mocktest do
   use ExUnit.Case, async: true
 
-  alias Shopify.{Webhook, Request, Adapters.Mock}
+  alias Shopify.{
+    Webhook,
+    Product,
+    Request,
+    Adapters.Mock
+  }
 
   test "it puts an id for created resources" do
     body = "{\"webhook\": {\"address\": \"http://www.yoloship.it/webhook\"}}"
@@ -12,5 +17,22 @@ defmodule Shopify.Adapters.Mocktest do
       |> Mock.post()
 
     assert resource.id != nil
+  end
+
+  test "it filters resources when given query params" do
+    body =
+      "{\"products\": [{\"product_type\": \"Some Product\"},{\"product_type\": \"Some Other Product\"}]}"
+
+    {:ok, %{data: resource}} =
+      Shopify.session()
+      |> Request.new(
+        Product.all_url(),
+        %{product_type: "Some Product"},
+        Product.plural_resource(),
+        body
+      )
+      |> Mock.get()
+
+    assert length(resource) == 1
   end
 end

--- a/test/adapters/mock_utils_test.exs
+++ b/test/adapters/mock_utils_test.exs
@@ -1,0 +1,5 @@
+defmodule Shopify.MockUtilsTest do
+  use ExUnit.Case, async: true
+
+  doctest Shopify.Adapters.MockUtils
+end

--- a/test/fixtures/products.json
+++ b/test/fixtures/products.json
@@ -135,7 +135,7 @@
           ]
         }
       ],
-      "metafields_global_description_tag": "", 
+      "metafields_global_description_tag": "",
       "metafields_global_title_tag": "",
       "published_scope": ""
     },
@@ -274,7 +274,7 @@
           ]
         }
       ],
-      "metafields_global_description_tag": "", 
+      "metafields_global_description_tag": "",
       "metafields_global_title_tag": "",
       "published_scope": ""
     }

--- a/test/page_test.exs
+++ b/test/page_test.exs
@@ -3,7 +3,6 @@ defmodule Shopify.PageTest do
 
   alias Shopify.Page
 
-  @tag :asdf
   test "client can request a single page" do
     assert {:ok, response} = Shopify.session() |> Page.find(1, %{a: "a"})
     assert %Shopify.Response{} = response

--- a/test/page_test.exs
+++ b/test/page_test.exs
@@ -3,8 +3,9 @@ defmodule Shopify.PageTest do
 
   alias Shopify.Page
 
+  @tag :asdf
   test "client can request a single page" do
-    assert {:ok, response} = Shopify.session() |> Page.find(1)
+    assert {:ok, response} = Shopify.session() |> Page.find(1, %{a: "a"})
     assert %Shopify.Response{} = response
     assert 200 == response.code
     fixture = Fixture.load("../test/fixtures/pages/1.json", "page", Page.empty_resource())


### PR DESCRIPTION
Resolves #34 

The basic idea is to filter the resources after they have been loaded from the fixture, so `/products.json?product_type=Something` will select the products with product type "Something", if there are any in the fixture file.

The caveat are params that do not correspond to resource keys, for example `/products.json?since_id=123123`, those are simply being ignored for now, because implementing those might turn out to be a huge time sink and maybe even be impossible to do for all possible params.
The workaround for anyone in need of those params for now would be to implement the `Shopify.Adapters.Base` behaviour, pattern match the critical params and roll their own solution.

Example: 
```elixir
MyApp.ShopifyMockAdapter do
  @bevaviour Shopify.Adapters.Base

  def get(%{query_params: %{since_id: since_id} = req) do
    req
    |> Shopify.Adapters.Mock.authorize()
    |> Shopify.Adapters.Mock.respond()
    |> my_awesome_since_id_filter(since_id)
  end

  def get(req), do: Shopify.Adapters.Mock.get(req)

  defp my_awesome_since_id_filter(response) do
     # however this would work, take a look into MockUtils.filter_resources/2 for reference
  end

  # We don't care about anything but the get requests
  def post(req), do: Shopify.Adapters.Mock.post(req)
  def put(req, do: Shopify.Adapters.Mock.put(req)
  def delete(req), do: Shopify.Adapters.Mock.delete(req)
end
```