### PR TITLE
Introduce Shopify.Error to handle response failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ session = Shopify.session("shop-name", "access-token")
 
 # 'message' is a text description of the error.
 {:error, %Shopify.Response{code: 404, data: message}} = session |> Shopify.Product.find(1)
+
+# Failed requests return %Shopify.Error struct
+{:error, %Shopify.Error{reason: :econnrefused, source: :httpoison}} = session |> Shopify.Product.find(1)
+
 ```
 
 The `%Shopify.Response{}` struct contains two fields: code and data. Code is the HTTP

--- a/lib/shopify/adapters/http.ex
+++ b/lib/shopify/adapters/http.ex
@@ -27,4 +27,8 @@ defmodule Shopify.Adapters.HTTP do
   def handle_response({:ok, %HTTPoison.Response{status_code: code, body: body}}, resource) do
     Shopify.Response.new(code, body, resource)
   end
+
+  def handle_response({:error, %HTTPoison.Error{reason: reason}}, _resource) do
+    {:error, %Shopify.Error{reason: reason, source: :httpoison}}
+  end
 end

--- a/lib/shopify/error.ex
+++ b/lib/shopify/error.ex
@@ -1,0 +1,7 @@
+defmodule Shopify.Error do
+  defexception reason: nil, source: nil
+  @type t :: %__MODULE__{source: atom | nil, reason: any}
+
+  def message(%__MODULE__{reason: reason, source: nil}), do: inspect(reason)
+  def message(%__MODULE__{reason: reason, source: source}), do: "[#{source}] - #{inspect reason}"
+end

--- a/test/adapters/http_test.exs
+++ b/test/adapters/http_test.exs
@@ -1,0 +1,14 @@
+defmodule Shopify.Adapters.HTTPTest do
+  use ExUnit.Case, async: true
+
+  alias Shopify.{Adapters.HTTP, Error, Product}
+
+  test "it handles httpoison errors" do
+    result = {:error, %HTTPoison.Error{id: nil, reason: :econnrefused}}
+
+    assert {:error, %Error{} = error} = HTTP.handle_response(result, %Product{})
+
+    assert error.source == :httpoison
+    assert error.reason == :econnrefused
+  end
+end


### PR DESCRIPTION
@Ninigi thanks for a quick feedback on #37 

> I think returning {:error, %Shopify.Error{}} would bubble up, so guess your approach would work 👍
> We would have to put some thought into the error fields, since we might want to use it for the errors returned by the shopify api as well

I think we should keep returning shopify errors wrapped in `Shopify.Response`, because it **is** response.

And for failed requests we pass errors from `HTTPoison`. Actually `HTTPoison` does the same, passing errors from `hackney`. So with the solution I propose in this PR we get ability to handle these errors coming from the deep. 

> we would need a data and a code field to make it backwards compatible.

If we don't use `Shopify.Error` for API errors we don't really need to make it backward compatible. 

I tested this solution on my real app that exports thousands of records, by switching network on and off to produce network errors, and it worked well.