### PR TITLE
Add Variant.inventory_item_id and Shop.multi_location_enabled

### DIFF
--- a/lib/shopify/resources/shop.ex
+++ b/lib/shopify/resources/shop.ex
@@ -45,7 +45,8 @@ defmodule Shopify.Shop do
     :iana_timezone,
     :zip,
     :has_storefront,
-    :setup_required
+    :setup_required,
+    :multi_location_enabled
   ]
 
   @doc """
@@ -55,7 +56,7 @@ defmodule Shopify.Shop do
 
   ## Parameters
     - session: A `%Shopify.Session{}` struct.
-    
+
   ## Examples
       iex> Shopify.session |> Shopify.Shop.current
       {:ok, %Shopify.Shop{}}

--- a/lib/shopify/resources/variant.ex
+++ b/lib/shopify/resources/variant.ex
@@ -28,6 +28,7 @@ defmodule Shopify.Variant do
     :weight,
     :weight_unit,
     :id,
+    :inventory_item_id,
     :inventory_management,
     :inventory_policy,
     :inventory_quantity,


### PR DESCRIPTION
I'm upgrading my app to support [new way of inventory management](https://help.shopify.com/en/api/guides/inventory-migration-guide) and I discovered that currently there's one very important parameter is missing in `Variant` module:

`inventory_item_id`

After Aug 1st updating variant's inventory_quantity might become only possible via:

```
Shopify.InventoryLevel.set(session, %{
  location_id: location_id,
  inventory_item_id: inventory_item_id,
  available: 355
}
```

So I added the `inventory_item_id` to `Variant` as well as another new parameter `Shop. multi_location_enabled`.