### PR TITLE
Fix invalid typespecs

### DIFF
--- a/lib/shopify/resources/inventory_level.ex
+++ b/lib/shopify/resources/inventory_level.ex
@@ -38,7 +38,8 @@ defmodule Shopify.InventoryLevel do
       iex> Shopify.session |> Shopify.InventoryLevel.all(%{inventory_item_ids: [123]})
       {:ok, %Shopify.Response{}}
   """
-  @spec all(%Shopify.Session{}, map) :: %Shopify.Response{}
+  @spec all(%Shopify.Session{}, map) ::
+          {:ok, Shopify.Response.t()} | {:error, Shopify.Response.t()}
   def all(session, params)
 
   def all(%Shopify.Session{} = session, %{inventory_item_ids: _} = params),
@@ -66,7 +67,8 @@ defmodule Shopify.InventoryLevel do
       iex> Shopify.session |> Shopify.InventoryLevel.adjust(%{inventory_item_id: 123, location_id: 123, available_adjustment: 123})
       {:ok, %Shopify.Response{}}
   """
-  @spec adjust(%Shopify.Session{}, map) :: %Shopify.Response{}
+  @spec adjust(%Shopify.Session{}, map) ::
+          {:ok, Shopify.Response.t()} | {:error, Shopify.Response.t()}
   def adjust(
         %Shopify.Session{} = session,
         %{inventory_item_id: _, location_id: _, available_adjustment: _} = inventory_level
@@ -91,7 +93,8 @@ defmodule Shopify.InventoryLevel do
       iex> Shopify.session |> Shopify.InventoryLevel.connect(%{inventory_item_id: 123, location_id: 123})
       {:ok, %Shopify.Response{}}
   """
-  @spec connect(%Shopify.Session{}, map) :: %Shopify.Response{}
+  @spec connect(%Shopify.Session{}, map) ::
+          {:ok, Shopify.Response.t()} | {:error, Shopify.Response.t()}
   def connect(%Shopify.Session{} = session, %{inventory_item_id: _, location_id: _} = connection) do
     session
     |> Request.new(@plural <> "/connect.json", connection, singular_resource())
@@ -113,7 +116,8 @@ defmodule Shopify.InventoryLevel do
       iex> Shopify.session |> Shopify.InventoryLevel.set(%{inventory_item_id: 123, location_id: 123, available: 5})
       {:ok, %Shopify.Response{}}
   """
-  @spec set(%Shopify.Session{}, map) :: %Shopify.Response{}
+  @spec set(%Shopify.Session{}, map) ::
+          {:ok, Shopify.Response.t()} | {:error, Shopify.Response.t()}
   def set(
         %Shopify.Session{} = session,
         %{inventory_item_id: _, location_id: _, available: _} = inventory

--- a/lib/shopify/resources/marketing/engagement.ex
+++ b/lib/shopify/resources/marketing/engagement.ex
@@ -33,7 +33,8 @@ defmodule Shopify.MarketingEvent.Engagement do
       iex> Shopify.session |> Shopify.MarketingEvent.Engagement.create_multiple(1, [%Shopify.MarketingEvent.Engagement{occurred_on: "2018-12-01"}])
       {:ok, %Shopify.Response{}}
   """
-  @spec create_multiple(%Shopify.Session{}, integer, list(%__MODULE__{})) :: %Shopify.Response{}
+  @spec create_multiple(%Shopify.Session{}, integer, list(%__MODULE__{})) ::
+          {:ok, Shopify.Response.t()} | {:error, Shopify.Response.t()}
   def create_multiple(%Shopify.Session{} = session, marketing_event_id, engagements) do
     body = engagements |> to_json()
 

--- a/lib/shopify/resources/marketing_event.ex
+++ b/lib/shopify/resources/marketing_event.ex
@@ -55,7 +55,7 @@ defmodule Shopify.MarketingEvent do
           %Shopify.Session{},
           integer,
           list(%Shopify.MarketingEvent.Engagement{})
-        ) :: %Shopify.Response{}
+        ) :: {:ok, Shopify.Response.t()} | {:error, Shopify.Response.t()}
   def create_multiple_engagements(%Shopify.Session{} = session, marketing_event_id, engagements) do
     __MODULE__.Engagement.create_multiple(session, marketing_event_id, engagements)
   end


### PR DESCRIPTION
I was getting this warning because of wrong type spec declaration in `InventoryLevel`. Fixed couple of other files as well.

<img width="752" alt="service ex" src="https://user-images.githubusercontent.com/1533802/43535370-609ed12c-95ec-11e8-91cc-61109be6de91.png">

Dialyzer considered this code invalid:

```
case result do
    {:ok, _} ->
        ...
    {:error, response} ->
        ...
end
```