### PR TITLE
Fix fulfillment event struct

### DIFF
--- a/lib/shopify/resources/order/fulfillment/event.ex
+++ b/lib/shopify/resources/order/fulfillment/event.ex
@@ -4,10 +4,26 @@ defmodule Shopify.Order.Fulfillment.Event do
 
   use Shopify.Resource
 
-  defstruct %Shopify.Event{} |> Map.keys() |> List.delete(:__struct__)
+  defstruct [
+    :id,
+    :fulfillment_id,
+    :status,
+    :message,
+    :happened_at,
+    :city,
+    :province,
+    :country,
+    :zip,
+    :address1,
+    :latitude,
+    :longitude,
+    :shop_id,
+    :estimated_delivery_at,
+    :order_id
+  ]
 
   @doc false
-  def empty_resource, do: Shopify.Event.empty_resource()
+  def empty_resource, do: %__MODULE__{}
 
   def all(%Shopify.Session{} = session, order_id, fulfillment_id, params \\ %{}) do
     session


### PR DESCRIPTION
Closes #45 

The Struct used for fulfillment events was the the generic event struct, but it needs to be a different event.