### PR TITLE
Add metafields key to Product struct

### DIFF
--- a/lib/shopify/resources/product.ex
+++ b/lib/shopify/resources/product.ex
@@ -33,6 +33,7 @@ defmodule Shopify.Product do
     :tags,
     :template_suffix,
     :title,
+    :metafields,
     :metafields_global_title_tag,
     :metafields_global_description_tag,
     :updated_at,


### PR DESCRIPTION
`Product` does not have a metafields key, which makes sense in a way, because we do not receive metafields as part of the products request responses. But we can send metafields as part of the create endpoint.

It is annoying that we have to include a key in the struct that will be nil 99% of the times, but it feels like the easiest way to solve this.