### PR TITLE
Fix mock oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ config :shopify, [
 ]
 ```
 
+When using oauth, make sure the token passed is `test`, otherwise authentication will fail.
+
+```
+Shopify.session("my-shop.myshopify.com", "test")
+|> Product.all()
+```
+
 ### Test Adapter
 
 This plugin provides a test adapter called `Shopify.Adapters.Mock` to use out of the box. It makes certain assumptions about your fixtures and is limited to the responses provided in corresponding fixture files, and for create actions it will put the resource id as 1.

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -90,5 +90,6 @@ defmodule Shopify.Adapters.Mock do
   end
 
   def oauth_auth(_) do
+    {:passed, request}
   end
 end

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -90,6 +90,9 @@ defmodule Shopify.Adapters.Mock do
   end
 
   def oauth_auth(request) do
-    {:passed, request}
+    case request.headers[:"X-Shopify-Access-Token"] do
+      "test" -> {:passed, request}
+      _ -> {:failed, request}
+    end
   end
 end

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -89,7 +89,7 @@ defmodule Shopify.Adapters.Mock do
     end
   end
 
-  def oauth_auth(_) do
+  def oauth_auth(request) do
     {:passed, request}
   end
 end

--- a/test/adapters/mock_test.exs
+++ b/test/adapters/mock_test.exs
@@ -35,4 +35,16 @@ defmodule Shopify.Adapters.Mocktest do
 
     assert length(resource) == 1
   end
+
+  test "it can use oauth when token is \"test\"" do
+    assert {:ok, _} =
+             Shopify.session("shop-name.myshopify.com", "test")
+             |> Shopify.Product.all()
+  end
+
+  test "it fails authentication when oauth token is anything other than \"test\"" do
+    assert {:error, _} =
+             Shopify.session("shop-name.myshopify.com", "fail")
+             |> Shopify.Product.all()
+  end
 end


### PR DESCRIPTION
Oauth flow was not supported in mock adapter. The way I implemented it, it will pass authentication when the token is "test" and fail otherwise.

Closes #57 