### PR TITLE
Patch update

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,36 @@ The `%Shopify.Response{}` struct contains two fields: code and data. Code is the
 status code that is returned from Shopify. A successful request will either set the data field
 with a single struct, or list of structs of the resource or resources requested.
 
+## `update` VS `patch_update`
+
+The main difference between `update` and `patch_update` is that `patch update` works with a map, instead of a struct.
+In most use cases, `update` and `patch_update` could be used interchangeably:
+
+```elixir
+session |> Shopify.Product.update(123123, %Shopify.Product{tags: "updated,tags"})
+# or
+session |> Shopify.Product.patch_update(123123, %{tags: "updated,tags"})
+```
+
+However, structs can not be initialized without all keys, meaning `%Shopify.Product{tags: "updated,tags"}` will result
+in a struct that populates all other keys with nil `%Shopify.Product{tags: "updated,tags", title: nil, id: nil, ...}`.
+For that reason, the Shopify package will ignore all `nil` values in a struct, so we do not accidentally set a value to null.
+As a result, updates with `nil` values are only possible using `patch_update`
+
+```elixir
+session |> Shopify.Product.update(123123, %Shopify.Product{tags: nil}) # does nothing!
+# VS
+session |> Shopify.Product.patch_update(123123, %{tags: nil}) # will reset the tags
+```
+
+The other important difference is `patch_update` does not provide key validations.
+
+```elixir
+session |> Shopify.Product.update(123123, %Shopify.Product{tgas: nil}) # will raise an error
+# VS
+session |> Shopify.Product.patch_update(123123, %{tgas: nil}) # will not complain at all, making it harder to debug
+```
+
 ## Testing
 
 For testing a mock adapter can be configured to use fixture json files instead of doing real requests.
@@ -245,68 +275,68 @@ Or for `Shopify.Product.find(1)`
 - Address
 - ApplicationCharge (find, all, create, activate)
 - ApplicationCredit (find, all, create)
-- Article (find, all, create, update, delete, count)
+- Article (find, all, create, update, patch_update, delete, count)
 - Article.Author (all)
 - Article.Tag (all)
 - Attribute
 - BillingAddress
-- Blog (find, all, create, update, delete, count)
-- CarrierService (find, all, create, update, delete)
+- Blog (find, all, create, update, patch_update, delete, count)
+- CarrierService (find, all, create, update, patch_update, delete)
 - Checkout (all, count)
 - ClientDetails
 - Collect (find, all, create, delete, count)
 - CollectionListing (find, all)
-- Comment (find, all, create, update, spam, not_spam, approve, remove, restore)
-- Country (find, all, create, update, delete, count)
-- Country.Province (find, all, update, count)
-- CustomCollection (find, all, create, update, delete, count)
-- Customer (find, all, create, update, delete, count, search)
+- Comment (find, all, create, update, patch_update, spam, not_spam, approve, remove, restore)
+- Country (find, all, create, update, patch_update, delete, count)
+- Country.Province (find, all, update, patch_update, count)
+- CustomCollection (find, all, create, update, patch_update, delete, count)
+- Customer (find, all, create, update, patch_update, delete, count, search)
 - CustomerAddress (find, all, create, delete)
-- CustomerSavedSearch (find, all, create, update, delete, count)
+- CustomerSavedSearch (find, all, create, update, patch_update, delete, count)
 - CustomerSavedSearch.Customer (all)
 - DiscountCode
-- DraftOrder (find, all, create, update, delete, count, complete, send_invoice) *`send_invoice` is an alias of `DraftOrder.DraftOrderInvoice.create/3`*
+- DraftOrder (find, all, create, update, patch_update, delete, count, complete, send_invoice) *`send_invoice` is an alias of `DraftOrder.DraftOrderInvoice.create/3`*
 - DraftOrder.DraftOrderInvoice (create)
 - MarketingEvent.Engagement (create_multiple)
 - Event (find, all, count)
-- Order.Fullfillment (find, all, count, create, update, complete, open, cancel)
+- Order.Fullfillment (find, all, count, create, update, patch_update, complete, open, cancel)
 - Order.Fullfillment.Event (find, all, delete)
-- FulfillmentService (find, all, create, update, delete)
-- Image (ProductImage) (find, all, create, update, delete, count)
+- FulfillmentService (find, all, create, update, patch_update, delete)
+- Image (ProductImage) (find, all, create, update, patch_update, delete, count)
 - InventoryLevel (all, delete)
 - LineItem
 - Location (find, all, count)
-- MarketingEvent (find, all, count, create, update, delete, create_multiple_engagements) *`create_multiple_engagements` is an alias of `MarketingEvent.Engagement.create_multiple/3`*
+- MarketingEvent (find, all, count, create, update, patch_update, delete, create_multiple_engagements) *`create_multiple_engagements` is an alias of `MarketingEvent.Engagement.create_multiple/3`*
 - Metafield
 - OAuth.AccessScope (all)
 - Option
-- Order (find, all, create, update, delete, count)
+- Order (find, all, create, update, patch_update, delete, count)
 - Order.Event (all)
-- Order.Risk (create, find, all, update, delete)
-- Page (create, find, all, update, delete, count)
+- Order.Risk (create, find, all, update, patch_update, delete)
+- Page (create, find, all, update, patch_update, delete, count)
 - PaymentDetails
 - Policy (all)
-- PriceRule (find, all, create, update, delete)
-- PriceRule.DiscountCode (find, all, create, update, delete)
-- Product (find, all, create, update, delete, count)
+- PriceRule (find, all, create, update, patch_update, delete)
+- PriceRule.DiscountCode (find, all, create, update, patch_update, delete)
+- Product (find, all, create, update, patch_update, delete, count)
 - Product.Event (all)
-- ProductListing (find, all, create, update, delete, count, product_ids)
+- ProductListing (find, all, create, update, patch_update, delete, count, product_ids)
 - RecurringApplicationCharge (find, all, create, activate, delete)
-- Redirect (find, all, create, update, delete, count)
+- Redirect (find, all, create, update, patch_update, delete, count)
 - Refund (create, find, all)
-- Report (create, find, all, update, delete)
+- Report (create, find, all, update, patch_update, delete)
 - ScriptTag (find, all, create, count, delete)
 - ShippingAddress
 - ShippingLine
 - Shop (current)
-- SmartCollection (find, all, create, count, update, delete)
+- SmartCollection (find, all, create, count, update, patch_update, delete)
 - TaxLine
-- Theme (find, all, create, update, delete)
+- Theme (find, all, create, update, patch_update, delete)
 - Theme.Asset (find, all, delete)
 - Transaction (find, all, create, count)
 - UsageCharge (find, all, create)
-- Variant (find, all, create, update, delete, count)
-- Webhook (find, all, create, update, delete, count)
+- Variant (find, all, create, update, patch_update, delete, count)
+- Webhook (find, all, create, update, patch_update, delete, count)
 
 ## Contributors
 

--- a/lib/shopify/adapters/base.ex
+++ b/lib/shopify/adapters/base.ex
@@ -9,6 +9,7 @@ defmodule Shopify.Adapters.Base do
 
   @callback get(Shopify.Request.t()) :: success | error
   @callback put(Shopify.Request.t()) :: success | error
+  @callback patch(Shopify.Request.t()) :: success | error
   @callback post(Shopify.Request.t()) :: success | error
   @callback delete(Shopify.Request.t()) :: success | error
 end

--- a/lib/shopify/adapters/http.ex
+++ b/lib/shopify/adapters/http.ex
@@ -22,6 +22,12 @@ defmodule Shopify.Adapters.HTTP do
     |> handle_response(request.resource)
   end
 
+  def patch(request) do
+    request.full_url
+    |> HTTPoison.patch(request.body || "", request.headers, merge_options(request.opts))
+    |> handle_response(request.resource)
+  end
+
   def delete(request) do
     request.full_url
     |> HTTPoison.delete(request.headers, merge_options(request))

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -35,6 +35,12 @@ defmodule Shopify.Adapters.Mock do
     |> respond
   end
 
+  def patch(request) do
+    request
+    |> authorize
+    |> respond
+  end
+
   def delete(request) do
     auth = request |> authorize
 

--- a/lib/shopify/client.ex
+++ b/lib/shopify/client.ex
@@ -9,5 +9,7 @@ defmodule Shopify.Client do
 
   def put(request), do: Config.client_adapter().put(request)
 
+  def patch(request), do: Config.client_adapter().patch(request)
+
   def delete(request), do: Config.client_adapter().delete(request)
 end

--- a/lib/shopify/resource.ex
+++ b/lib/shopify/resource.ex
@@ -131,11 +131,33 @@ defmodule Shopify.Resource do
             {:ok, %Shopify.Response{}}
         """
         def update(session, id, updated_resource) do
-          body = updated_resource |> to_json
+          body = updated_resource |> to_json()
 
           session
           |> Request.new(find_url(id), %{}, singular_resource(), body)
           |> Client.put()
+        end
+
+        @doc """
+        Requests to partly update a resource by id.
+
+        Returns `{:ok, %Shopify.Response{}}` or `{:error, %Shopify.Response{}}`
+
+        ## Parameters
+          - session: A `%Shopify.Session{}` struct.
+          - id: The id of the resource.
+          - update_args: A map of the attributes being updated.
+
+        ## Examples
+            iex> Shopify.session |> Shopify.Product.patch_update(id, %{title: "Update"})
+            {:ok, %Shopify.Response{data: %Shopify.Product{title: "Update"}}}
+        """
+        def patch_update(session, id, update_args) do
+          body = update_args |> to_patch_json()
+
+          session
+          |> Request.new(find_url(id), %{}, singular_resource(), body)
+          |> Client.patch()
         end
       end
 
@@ -181,7 +203,12 @@ defmodule Shopify.Resource do
         |> Map.from_struct()
         |> Enum.filter(fn {_, v} -> v != nil end)
         |> Enum.into(%{})
-        |> singular_resource
+        |> to_patch_json()
+      end
+
+      def to_patch_json(resource) do
+        resource
+        |> singular_resource()
         |> Poison.encode!()
       end
     end

--- a/test/article_test.exs
+++ b/test/article_test.exs
@@ -69,6 +69,12 @@ defmodule Shopify.ArticleTest do
     assert "Update" == response.data.title
   end
 
+  test "client can request to patch update a product" do
+    update = %{title: "Update"}
+    assert {:ok, response} = Shopify.session() |> Article.patch_update(1, 1, update)
+    assert "Update" == response.data.title
+  end
+
   test "client can request to delete an article" do
     assert {:ok, response} = Shopify.session() |> Article.delete(1, 1)
     assert %Shopify.Response{} = response

--- a/test/checkout_test.exs
+++ b/test/checkout_test.exs
@@ -59,6 +59,16 @@ defmodule Shopify.CheckoutTest do
     assert 123 == response.data.customer_id
   end
 
+  test "client can request to patch update a product" do
+    update = %{customer_id: 123}
+
+    assert {:ok, response} =
+             Shopify.session()
+             |> Checkout.patch_update("exuw7apwoycchjuwtiqg8nytfhphr62a", update)
+
+    assert 123 == response.data.customer_id
+  end
+
   test "client can request to complete a checkout without payment" do
     assert {:ok, response} =
              Shopify.session() |> Checkout.complete("exuw7apwoycchjuwtiqg8nytfhphr62a")

--- a/test/checkout_test.exs
+++ b/test/checkout_test.exs
@@ -59,7 +59,7 @@ defmodule Shopify.CheckoutTest do
     assert 123 == response.data.customer_id
   end
 
-  test "client can request to patch update a product" do
+  test "client can request to patch update a checkout" do
     update = %{customer_id: 123}
 
     assert {:ok, response} =

--- a/test/comment_test.exs
+++ b/test/comment_test.exs
@@ -55,6 +55,12 @@ defmodule Shopify.CommentTest do
     assert "Update" == response.data.author
   end
 
+  test "client can request to patch update a comment" do
+    update = %{author: "Update"}
+    assert {:ok, response} = Shopify.session() |> Comment.patch_update(1, update)
+    assert "Update" == response.data.author
+  end
+
   test "client can mark a comment as spam" do
     assert {:ok, response} = Shopify.session() |> Comment.spam(1)
     assert %Shopify.Response{} = response

--- a/test/country_test.exs
+++ b/test/country_test.exs
@@ -55,6 +55,12 @@ defmodule Shopify.CountryTest do
     assert "Update" == response.data.code
   end
 
+  test "client can request to patch update an country" do
+    update = %{code: "Update"}
+    assert {:ok, response} = Shopify.session() |> Country.patch_update(1, update)
+    assert "Update" == response.data.code
+  end
+
   test "client can request to delete an country" do
     assert {:ok, response} = Shopify.session() |> Country.delete(1)
     assert %Shopify.Response{} = response

--- a/test/customer_saved_search_test.exs
+++ b/test/customer_saved_search_test.exs
@@ -69,6 +69,12 @@ defmodule Shopify.CustomerSavedSearchTest do
     assert "Update" == response.data.name
   end
 
+  test "client can request to patch update an customer_saved_search" do
+    update = %{name: "Update"}
+    assert {:ok, response} = Shopify.session() |> CustomerSavedSearch.patch_update(1, update)
+    assert "Update" == response.data.name
+  end
+
   test "client can request to delete an customer_saved_search" do
     assert {:ok, response} = Shopify.session() |> CustomerSavedSearch.delete(1)
     assert %Shopify.Response{} = response

--- a/test/customer_test.exs
+++ b/test/customer_test.exs
@@ -58,6 +58,12 @@ defmodule Shopify.CustomerTest do
     assert "Update" == response.data.first_name
   end
 
+  test "client can request to patch update a customer" do
+    update = %{first_name: "Update"}
+    assert {:ok, response} = Shopify.session() |> Customer.patch_update(1, update)
+    assert "Update" == response.data.first_name
+  end
+
   test "client can request to delete a customer" do
     assert {:ok, response} = Shopify.session() |> Customer.delete(1)
     assert %Shopify.Response{} = response

--- a/test/draft_order_test.exs
+++ b/test/draft_order_test.exs
@@ -72,6 +72,12 @@ defmodule Shopify.DraftOrderTest do
     assert "Update" == response.data.status
   end
 
+  test "client can request to patch update an draft_order" do
+    update = %{status: "Update"}
+    assert {:ok, response} = Shopify.session() |> DraftOrder.patch_update(1, update)
+    assert "Update" == response.data.status
+  end
+
   test "client can request to delete an draft_order" do
     assert {:ok, response} = Shopify.session() |> DraftOrder.delete(1)
     assert %Shopify.Response{} = response

--- a/test/fulfillment_service_test.exs
+++ b/test/fulfillment_service_test.exs
@@ -61,6 +61,12 @@ defmodule Shopify.FulfillmentServiceTest do
     assert "Update" == response.data.name
   end
 
+  test "client can request to patch update a fulfillment_service" do
+    update = %{name: "Update"}
+    assert {:ok, response} = Shopify.session() |> FulfillmentService.patch_update(1, update)
+    assert "Update" == response.data.name
+  end
+
   test "client can request to delete a fulfillment_service" do
     assert {:ok, response} = Shopify.session() |> FulfillmentService.delete(1)
     assert %Shopify.Response{} = response

--- a/test/inventory_item_test.exs
+++ b/test/inventory_item_test.exs
@@ -38,4 +38,10 @@ defmodule Shopify.InventoryItemTest do
     assert {:ok, response} = Shopify.session() |> InventoryItem.update(1, update)
     assert "Update" == response.data.sku
   end
+
+  test "client can request to patch update a inventory_item" do
+    update = %{sku: "Update"}
+    assert {:ok, response} = Shopify.session() |> InventoryItem.patch_update(1, update)
+    assert "Update" == response.data.sku
+  end
 end

--- a/test/marketing_event_test.exs
+++ b/test/marketing_event_test.exs
@@ -69,6 +69,12 @@ defmodule Shopify.MarketingEventTest do
     assert "Update" == response.data.utm_source
   end
 
+  test "client can request to patch update an marketing_event" do
+    update = %{utm_source: "Update"}
+    assert {:ok, response} = Shopify.session() |> MarketingEvent.patch_update(1, update)
+    assert "Update" == response.data.utm_source
+  end
+
   test "client can request to delete an marketing_event" do
     assert {:ok, response} = Shopify.session() |> MarketingEvent.delete(1)
     assert %Shopify.Response{} = response

--- a/test/metafield_test.exs
+++ b/test/metafield_test.exs
@@ -55,6 +55,12 @@ defmodule Shopify.MetafieldTest do
     assert "Update" == response.data.value
   end
 
+  test "client can request to patch update a metafield" do
+    update = %{value: "Update"}
+    assert {:ok, response} = Shopify.session() |> Metafield.patch_update(1, update)
+    assert "Update" == response.data.value
+  end
+
   test "client can request to delete a metafield" do
     assert {:ok, response} = Shopify.session() |> Metafield.delete(1)
     assert %Shopify.Response{} = response

--- a/test/order/fulfillment_test.exs
+++ b/test/order/fulfillment_test.exs
@@ -69,6 +69,12 @@ defmodule Shopify.FulfillmentTest do
     assert "Update" == response.data.tracking_company
   end
 
+  test "client can request to patch update a fulfillment" do
+    update = %{tracking_company: "Update"}
+    assert {:ok, response} = Shopify.session() |> Fulfillment.patch_update(1, 1, update)
+    assert "Update" == response.data.tracking_company
+  end
+
   test "client can request to complete a fulfillment" do
     assert {:ok, response} = Shopify.session() |> Fulfillment.complete(1, 1)
     assert %Shopify.Response{} = response

--- a/test/order/risk_test.exs
+++ b/test/order/risk_test.exs
@@ -47,6 +47,12 @@ defmodule Shopify.RiskTest do
     assert "Update" == response.data.message
   end
 
+  test "client can request to patch update an risk" do
+    update = %{message: "Update"}
+    assert {:ok, response} = Shopify.session() |> Order.Risk.patch_update(1, 1, update)
+    assert "Update" == response.data.message
+  end
+
   test "client can request to delete an risk" do
     assert {:ok, response} = Shopify.session() |> Order.Risk.delete(1, 1)
     assert %Shopify.Response{} = response

--- a/test/order_test.exs
+++ b/test/order_test.exs
@@ -44,6 +44,12 @@ defmodule Shopify.OrderTest do
     assert "Update" == response.data.reference
   end
 
+  test "client can request to patch update an order" do
+    update = %{reference: "Update"}
+    assert {:ok, response} = Shopify.session() |> Order.patch_update(1, update)
+    assert "Update" == response.data.reference
+  end
+
   test "client can request to delete an order" do
     assert {:ok, response} = Shopify.session() |> Order.delete(1)
     assert %Shopify.Response{} = response

--- a/test/page_test.exs
+++ b/test/page_test.exs
@@ -44,6 +44,12 @@ defmodule Shopify.PageTest do
     assert "Update" == response.data.title
   end
 
+  test "client can request to patch update a page" do
+    update = %{title: "Update"}
+    assert {:ok, response} = Shopify.session() |> Page.patch_update(1, update)
+    assert "Update" == response.data.title
+  end
+
   test "client can request to delete a page" do
     assert {:ok, response} = Shopify.session() |> Page.delete(1)
     assert %Shopify.Response{} = response

--- a/test/price_rule/discount_code_test.exs
+++ b/test/price_rule/discount_code_test.exs
@@ -63,6 +63,12 @@ defmodule Shopify.PriceRule.DiscountCodeTest do
     assert "123Code" == response.data.code
   end
 
+  test "client can request to patch update a price_rule" do
+    update = %{code: "123Code"}
+    assert {:ok, response} = Shopify.session() |> DiscountCode.patch_update(1, 1, update)
+    assert "123Code" == response.data.code
+  end
+
   test "client can request to delete a price rule" do
     assert {:ok, response} = Shopify.session() |> DiscountCode.delete(1, 1)
     assert %Shopify.Response{} = response

--- a/test/price_rule_test.exs
+++ b/test/price_rule_test.exs
@@ -61,6 +61,12 @@ defmodule Shopify.PriceRuleTest do
     assert "Blehp" == response.data.title
   end
 
+  test "client can request to patch update a price_rule" do
+    update = %{title: "Blehp"}
+    assert {:ok, response} = Shopify.session() |> PriceRule.patch_update(1, update)
+    assert "Blehp" == response.data.title
+  end
+
   test "client can request to delete a price rule" do
     assert {:ok, response} = Shopify.session() |> PriceRule.delete(1)
     assert %Shopify.Response{} = response

--- a/test/product_listing_test.exs
+++ b/test/product_listing_test.exs
@@ -69,6 +69,12 @@ defmodule Shopify.ProductListingTest do
     assert "ipod-dont-touch" == response.data.handle
   end
 
+  test "client can request to patch update an product_listing" do
+    update = %{handle: "ipod-dont-touch"}
+    assert {:ok, response} = Shopify.session() |> ProductListing.patch_update(1, update)
+    assert "ipod-dont-touch" == response.data.handle
+  end
+
   test "client can request to delete an product_listing" do
     assert {:ok, response} = Shopify.session() |> ProductListing.delete(1)
     assert %Shopify.Response{} = response

--- a/test/product_test.exs
+++ b/test/product_test.exs
@@ -55,6 +55,12 @@ defmodule Shopify.ProductTest do
     assert "Update" == response.data.title
   end
 
+  test "client can request to patch update a product" do
+    update = %{title: "Update"}
+    assert {:ok, response} = Shopify.session() |> Product.patch_update(1, update)
+    assert "Update" == response.data.title
+  end
+
   test "client can request to delete a product" do
     assert {:ok, response} = Shopify.session() |> Product.delete(1)
     assert %Shopify.Response{} = response

--- a/test/province_test.exs
+++ b/test/province_test.exs
@@ -46,4 +46,10 @@ defmodule Shopify.Country.ProvinceTest do
     assert {:ok, response} = Shopify.session() |> Province.update(1, 1, update)
     assert "Update" == response.data.code
   end
+
+  test "client can request to patch update an province" do
+    update = %{code: "Update"}
+    assert {:ok, response} = Shopify.session() |> Province.patch_update(1, 1, update)
+    assert "Update" == response.data.code
+  end
 end

--- a/test/redirect_test.exs
+++ b/test/redirect_test.exs
@@ -55,6 +55,12 @@ defmodule Shopify.RedirectTest do
     assert "Update" == response.data.path
   end
 
+  test "client can request to patch update an redirect" do
+    update = %{path: "Update"}
+    assert {:ok, response} = Shopify.session() |> Redirect.patch_update(1, update)
+    assert "Update" == response.data.path
+  end
+
   test "client can request to delete an redirect" do
     assert {:ok, response} = Shopify.session() |> Redirect.delete(1)
     assert %Shopify.Response{} = response

--- a/test/report_test.exs
+++ b/test/report_test.exs
@@ -36,6 +36,12 @@ defmodule Shopify.ReportTest do
     assert "Update" == response.data.name
   end
 
+  test "client can request to patch update a report" do
+    update = %{name: "Update"}
+    assert {:ok, response} = Shopify.session() |> Report.patch_update(1, update)
+    assert "Update" == response.data.name
+  end
+
   test "client can request to delete a report" do
     assert {:ok, response} = Shopify.session() |> Report.delete(1)
     assert %Shopify.Response{} = response

--- a/test/smart_collection_test.exs
+++ b/test/smart_collection_test.exs
@@ -69,6 +69,12 @@ defmodule Shopify.SmartCollectionTest do
     assert "Update" == response.data.title
   end
 
+  test "client can request to patch update an smart_collection" do
+    update = %{title: "Update"}
+    assert {:ok, response} = Shopify.session() |> SmartCollection.patch_update(1, update)
+    assert "Update" == response.data.title
+  end
+
   test "client can request to delete an smart_collection" do
     assert {:ok, response} = Shopify.session() |> SmartCollection.delete(1)
     assert %Shopify.Response{} = response

--- a/test/theme_test.exs
+++ b/test/theme_test.exs
@@ -36,6 +36,12 @@ defmodule Shopify.ThemeTest do
     assert "Update" == response.data.name
   end
 
+  test "client can request to patch update an theme" do
+    update = %{name: "Update"}
+    assert {:ok, response} = Shopify.session() |> Theme.patch_update(1, update)
+    assert "Update" == response.data.name
+  end
+
   test "client can request to delete an theme" do
     assert {:ok, response} = Shopify.session() |> Theme.delete(1)
     assert %Shopify.Response{} = response

--- a/test/webhook_test.exs
+++ b/test/webhook_test.exs
@@ -55,6 +55,12 @@ defmodule Shopify.WebhookTest do
     assert "Update" == response.data.topic
   end
 
+  test "client can request to patch update a webhook" do
+    update = %{topic: "Update"}
+    assert {:ok, response} = Shopify.session() |> Webhook.patch_update(1, update)
+    assert "Update" == response.data.topic
+  end
+
   test "client can request to delete a webhook" do
     assert {:ok, response} = Shopify.session() |> Webhook.delete(1)
     assert %Shopify.Response{} = response


### PR DESCRIPTION
### Problem

The `Shopify.XResource.update` implementation needs a resource struct with the changes as an argument.

```elixir
Shopify.Product.update(session, 123123123, %Shopify.Product{tags: "new,tags"})
```

When a struct is initialized like this, it will use the default values for undefined fields (`nil`)

```elixir
%Shopify.Product{tags: "new,tags"}
# => %Shopify.Product{
# body_html: nil,
# created_at: nil,
# handle: nil,
# id: nil,
# images: nil,
# metafields: nil,
# metafields_global_description_tag: nil,
# metafields_global_title_tag: nil,
# options: nil,
# product_type: nil,
# published_at: nil,
# published_scope: nil,
# tags: "new,tags",
# template_suffix: nil,
# title: nil,
# updated_at: nil,
# variants: nil,
# vendor: nil
# }
```

The current implementation will remove all nil values, so we don't accidentally update values to null. As a result, `%Shopify.Product{tags: "new,tags"}` will only update tags, however resetting tags by updating them with nil `%Shopify.Product{tags: nil}` is not possible.

### Proposed solution

This PR introduces a `patch_update` function

```
Shopify.Product.patch_update(session, 123123123, %{tags: nil})
```

The main use case would be to be able to use `nil` values for updates, but can also provide a work around if one of our structs is missing a key.