### PR TITLE
Add :alt field to Image struct

### DIFF
--- a/lib/shopify/resources/image.ex
+++ b/lib/shopify/resources/image.ex
@@ -18,6 +18,7 @@ defmodule Shopify.Image do
   }
 
   defstruct [
+    :alt,
     :created_at,
     :id,
     :position,


### PR DESCRIPTION
Shopify product images have an `alt` field. It is mentioned [in this doc](https://help.shopify.com/en/api/reference/products/product-image#update).