### PR TITLE
Use valid properties for InventoryLevel

### DIFF
--- a/lib/shopify/resources/inventory_level.ex
+++ b/lib/shopify/resources/inventory_level.ex
@@ -13,10 +13,9 @@ defmodule Shopify.InventoryLevel do
     ]
 
   defstruct [
-    :id,
-    :sku,
-    :tracked,
-    :created_at,
+    :available,
+    :inventory_item_id,
+    :location_id,
     :updated_at
   ]
 


### PR DESCRIPTION
It looks like the wrong properties were placed on InventoryLevel, most
likely an unfortunate copy paste from InventoryItem.

https://help.shopify.com/en/api/reference/inventory/inventorylevel#properties

These properties are already correctly reflected in the fixture data.