### PR TITLE
Create and Update Functionality for Theme Assets

### DIFF
--- a/lib/shopify/resources/theme/asset.ex
+++ b/lib/shopify/resources/theme/asset.ex
@@ -3,6 +3,8 @@ defmodule Shopify.Theme.Asset do
   @singular "asset"
   @plural "assets"
 
+  alias Shopify.{Client, Request, Session}
+
   use Shopify.NestedResource,
     import: [
       :all,
@@ -35,4 +37,48 @@ defmodule Shopify.Theme.Asset do
 
   @doc false
   defp url_prefix(theme_id), do: "themes/#{theme_id}"
+
+  @doc """
+  Requests to create a new resource.
+
+  Returns `{:ok, %Shopify.Response{}}` or `{:error, %Shopify.Response{}}`
+
+  ## Parameters
+    - session: A `%Shopify.Session{}` struct.
+    - top_id: The id of the top-level resource.
+    - new_resource: A struct of the resource being created.
+
+  ## Examples
+      iex> Shopify.session |> Shopify.Theme.Asset.create(theme_id)
+      {:ok, %Shopify.Response{}}
+  """
+  def create(%Session{} = session, top_id, new_resource) do
+    body = new_resource |> to_json
+
+    session
+    |> Request.new(all_url(top_id), %{}, empty_resource(), body)
+    |> Client.put()
+  end
+
+  @doc """
+  Requests to update a resource by id.
+
+  Returns `{:ok, %Shopify.Response{}}` or `{:error, %Shopify.Error{}}`
+
+  ## Parameters
+    - session: A `%Shopify.Session{}` struct.
+    - top_id: The id of the top-level resource.
+    - updated_resource: A struct of the resource being updated.
+
+  ## Examples
+      iex> Shopify.session |> Shopify.Theme.Asset.update(theme_id)
+      {:ok, %Shopify.Response{}}
+  """
+  def update(%Session{} = session, top_id, updated_resource) do
+    body = updated_resource |> to_json
+
+    session
+    |> Request.new(all_url(top_id), %{}, empty_resource(), body)
+    |> Client.put()
+  end
 end


### PR DESCRIPTION
Shopify's theme asset API endpoints for create and update both expect a request of type PUT and do not take a resource id (nor the asset key as a param as the find or delete functions do).