### PR TITLE
Shopify Payments: Payouts

### DIFF
--- a/lib/shopify/resources/shopify_payments/payout.ex
+++ b/lib/shopify/resources/shopify_payments/payout.ex
@@ -1,0 +1,35 @@
+defmodule Shopify.ShopifyPayments.Payout do
+  @derive [Poison.Encoder]
+  @singular "payout"
+  @plural "payouts"
+
+  use Shopify.Resource,
+    import: [
+      :find,
+      :all
+    ]
+
+  alias Shopify.ShopifyPayments.PayoutSummary
+
+  defstruct [
+    :amount,
+    :currency,
+    :date,
+    :id,
+    :status,
+    :summary
+  ]
+
+  @doc false
+  def empty_resource do
+    %__MODULE__{
+      summary: %PayoutSummary{}
+    }
+  end
+
+  @doc false
+  def find_url(id), do: "shopify_payments/#{@plural}/#{id}.json"
+
+  @doc false
+  def all_url, do: "shopify_payments/#{@plural}.json"
+end

--- a/lib/shopify/resources/shopify_payments/payout_summary.ex
+++ b/lib/shopify/resources/shopify_payments/payout_summary.ex
@@ -1,0 +1,18 @@
+defmodule Shopify.ShopifyPayments.PayoutSummary do
+  @moduledoc false
+
+  @derive [Poison.Encoder]
+
+  defstruct [
+    :adjustments_fee_amount,
+    :adjustments_gross_amount,
+    :charges_fee_amount,
+    :charges_gross_amount,
+    :refunds_fee_amount,
+    :refunds_gross_amount,
+    :reserved_funds_fee_amount,
+    :reserved_funds_gross_amount,
+    :retried_payouts_fee_amount,
+    :retried_payouts_gross_amount
+  ]
+end

--- a/test/fixtures/shopify_payments/payouts.json
+++ b/test/fixtures/shopify_payments/payouts.json
@@ -1,0 +1,42 @@
+{
+  "payouts": [
+    {
+      "id": 2,
+      "status": "in_transit",
+      "date": "2019-11-08",
+      "currency": "USD",
+      "amount": "722.79",
+      "summary": {
+        "adjustments_fee_amount": "0.00",
+        "adjustments_gross_amount": "0.68",
+        "charges_fee_amount": "22.30",
+        "charges_gross_amount": "771.40",
+        "refunds_fee_amount": "0.00",
+        "refunds_gross_amount": "-26.99",
+        "reserved_funds_fee_amount": "0.00",
+        "reserved_funds_gross_amount": "0.00",
+        "retried_payouts_fee_amount": "0.00",
+        "retried_payouts_gross_amount": "0.00"
+      }
+    },
+    {
+      "id": 1,
+      "status": "paid",
+      "date": "2019-11-07",
+      "currency": "USD",
+      "amount": "1175.07",
+      "summary": {
+        "adjustments_fee_amount": "-30.00",
+        "adjustments_gross_amount": "63.22",
+        "charges_fee_amount": "32.69",
+        "charges_gross_amount": "1114.54",
+        "refunds_fee_amount": "0.00",
+        "refunds_gross_amount": "0.00",
+        "reserved_funds_fee_amount": "0.00",
+        "reserved_funds_gross_amount": "0.00",
+        "retried_payouts_fee_amount": "0.00",
+        "retried_payouts_gross_amount": "0.00"
+      }
+    }
+  ]
+}

--- a/test/fixtures/shopify_payments/payouts/1.json
+++ b/test/fixtures/shopify_payments/payouts/1.json
@@ -1,0 +1,21 @@
+{
+  "payout": {
+    "id": 1,
+    "status": "paid",
+    "date": "2019-11-07",
+    "currency": "USD",
+    "amount": "1175.07",
+    "summary": {
+      "adjustments_fee_amount": "-30.00",
+      "adjustments_gross_amount": "63.22",
+      "charges_fee_amount": "32.69",
+      "charges_gross_amount": "1114.54",
+      "refunds_fee_amount": "0.00",
+      "refunds_gross_amount": "0.00",
+      "reserved_funds_fee_amount": "0.00",
+      "reserved_funds_gross_amount": "0.00",
+      "retried_payouts_fee_amount": "0.00",
+      "retried_payouts_gross_amount": "0.00"
+    }
+  }
+}

--- a/test/shopify_payments/payout_test.exs
+++ b/test/shopify_payments/payout_test.exs
@@ -1,0 +1,21 @@
+defmodule Shopify.ShopifyPayments.PayoutTest do
+  use ExUnit.Case, async: true
+
+  alias Shopify.ShopifyPayments.Payout
+
+  test "client can request a single payout" do
+    assert {:ok, response} = Shopify.session() |> Payout.find(1)
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    fixture = Fixture.load("../test/fixtures/shopify_payments/payouts/1.json", "payout", Payout.empty_resource())
+    assert fixture == response.data
+  end
+
+  test "client can request all payouts" do
+    assert {:ok, response} = Shopify.session() |> Payout.all()
+    assert %Shopify.Response{} = response
+    assert 200 == response.code
+    fixture = Fixture.load("../test/fixtures/shopify_payments/payouts.json", "payouts", [Payout.empty_resource()])
+    assert fixture == response.data
+  end
+end


### PR DESCRIPTION
Adds Payout resource as part of Shopify Payments. 

see https://help.shopify.com/en/api/reference/shopify_payments/payout

How does this look?