### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,27 @@
+name: Elixir CI
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Elixir supports security patches for the most recent 5 versions. See
+        # https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Compatibility%20and%20Deprecations.md
+        elixir_container: [alpine, 1.9-alpine, 1.8-alpine, 1.7-alpine, 1.6-alpine, 1.5-alpine]
+
+    container:
+      image: elixir:${{ matrix.elixir_container }}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+    - name: Run Tests
+      run: mix test


### PR DESCRIPTION
The current `.travis.yml` is using the old and unsupported Elixir version of 1.4 and an old version of OTP too. This pull-request switches to Github Actions and builds on a matrix of all supported Elixir versions. If https://github.com/c0b/docker-elixir/issues/122 is resolved then the matrix could also include OTP versions.

If this is merged then you'll probably want to disable Travis CI on this repo. Thanks ❤️ 