### PR TITLE
Add `headers` to `Shopify.Response` struct

### DIFF
--- a/lib/shopify/adapters/http.ex
+++ b/lib/shopify/adapters/http.ex
@@ -28,8 +28,8 @@ defmodule Shopify.Adapters.HTTP do
     |> handle_response(request.resource)
   end
 
-  def handle_response({:ok, %HTTPoison.Response{status_code: code, body: body}}, resource) do
-    Shopify.Response.new(%{body: body, code: code}, resource)
+  def handle_response({:ok, %HTTPoison.Response{} = resp}, resource) do
+    Shopify.Response.new(%{body: resp.body, code: resp.status_code, headers: resp.headers}, resource)
   end
 
   def handle_response({:error, %HTTPoison.Error{reason: reason}}, _resource) do

--- a/lib/shopify/adapters/http.ex
+++ b/lib/shopify/adapters/http.ex
@@ -29,7 +29,7 @@ defmodule Shopify.Adapters.HTTP do
   end
 
   def handle_response({:ok, %HTTPoison.Response{status_code: code, body: body}}, resource) do
-    Shopify.Response.new(code, body, resource)
+    Shopify.Response.new(%{body: body, code: code}, resource)
   end
 
   def handle_response({:error, %HTTPoison.Error{reason: reason}}, _resource) do

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -39,13 +39,13 @@ defmodule Shopify.Adapters.Mock do
     auth = request |> authorize
 
     case auth do
-      {:passed, _} -> Response.new(200, nil, request.resource)
+      {:passed, _} -> Response.new(%{code: 200, body: nil}, request.resource)
       {:failed, _} -> respond(auth)
     end
   end
 
   def respond({:failed, request}) do
-    Response.new(401, nil, request.resource)
+    Response.new(%{code: 401, body: nil}, request.resource)
   end
 
   def respond({:passed, request}) do
@@ -55,11 +55,11 @@ defmodule Shopify.Adapters.Mock do
   end
 
   def respond({:ok, body}, request) do
-    Response.new(200, body, request.resource)
+    Response.new(%{code: 200, body: body}, request.resource)
   end
 
   def respond({:error, _}, request) do
-    Response.new(404, nil, request.resource)
+    Response.new(%{code: 404, body: nil}, request.resource)
   end
 
   def load_resource(%Request{path: path, body: nil}) do

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -39,13 +39,13 @@ defmodule Shopify.Adapters.Mock do
     auth = request |> authorize
 
     case auth do
-      {:passed, _} -> Response.new(%{code: 200, body: nil}, request.resource)
+      {:passed, _} -> Response.new(%{code: 200, body: nil, headers: []}, request.resource)
       {:failed, _} -> respond(auth)
     end
   end
 
   def respond({:failed, request}) do
-    Response.new(%{code: 401, body: nil}, request.resource)
+    Response.new(%{code: 401, body: nil, headers: []}, request.resource)
   end
 
   def respond({:passed, request}) do
@@ -55,11 +55,11 @@ defmodule Shopify.Adapters.Mock do
   end
 
   def respond({:ok, body}, request) do
-    Response.new(%{code: 200, body: body}, request.resource)
+    Response.new(%{code: 200, body: body, headers: []}, request.resource)
   end
 
   def respond({:error, _}, request) do
-    Response.new(%{code: 404, body: nil}, request.resource)
+    Response.new(%{code: 404, body: nil, headers: []}, request.resource)
   end
 
   def load_resource(%Request{path: path, body: nil}) do

--- a/lib/shopify/resources/inventory_level.ex
+++ b/lib/shopify/resources/inventory_level.ex
@@ -134,5 +134,5 @@ defmodule Shopify.InventoryLevel do
   @doc false
   def all_url, do: @plural <> ".json"
 
-  defp unprocessable_entity(msg), do: Shopify.Response.new(%{body: msg, code: 422}, empty_resource())
+  defp unprocessable_entity(msg), do: Shopify.Response.new(%{body: msg, code: 422, headers: []}, empty_resource())
 end

--- a/lib/shopify/resources/inventory_level.ex
+++ b/lib/shopify/resources/inventory_level.ex
@@ -134,5 +134,5 @@ defmodule Shopify.InventoryLevel do
   @doc false
   def all_url, do: @plural <> ".json"
 
-  defp unprocessable_entity(msg), do: Shopify.Response.new(422, msg, empty_resource())
+  defp unprocessable_entity(msg), do: Shopify.Response.new(%{body: msg, code: 422}, empty_resource())
 end

--- a/lib/shopify/response.ex
+++ b/lib/shopify/response.ex
@@ -7,15 +7,16 @@ defmodule Shopify.Response do
 
   defstruct [
     :code,
-    :data
+    :data,
+    :headers
   ]
 
-  def new(%{body: body, code: code}, resource) when code < 300 do
-    {:ok, %Response{code: code, data: resource |> parse_json(body)}}
+  def new(%{body: body, code: code, headers: headers}, resource) when code < 300 do
+    {:ok, %Response{code: code, data: resource |> parse_json(body), headers: headers}}
   end
 
-  def new(%{body: body, code: code}, error) do
-    {:error, %Response{code: code, data: error |> parse_json(body)}}
+  def new(%{body: body, code: code, headers: headers}, error) do
+    {:error, %Response{code: code, data: error |> parse_json(body), headers: headers}}
   end
 
   defp parse_json(_res, body) when is_nil(body) or body == "" do

--- a/lib/shopify/response.ex
+++ b/lib/shopify/response.ex
@@ -10,11 +10,11 @@ defmodule Shopify.Response do
     :data
   ]
 
-  def new(code, body, resource) when code < 300 do
+  def new(%{body: body, code: code}, resource) when code < 300 do
     {:ok, %Response{code: code, data: resource |> parse_json(body)}}
   end
 
-  def new(code, body, error) do
+  def new(%{body: body, code: code}, error) do
     {:error, %Response{code: code, data: error |> parse_json(body)}}
   end
 

--- a/test/adapters/http_test.exs
+++ b/test/adapters/http_test.exs
@@ -1,12 +1,26 @@
 defmodule Shopify.Adapters.HTTPTest do
   use ExUnit.Case, async: true
 
-  alias Shopify.{Adapters.HTTP, Session, Request, Error, Product}
+  alias Shopify.{Adapters.HTTP, Session, Request, Response, Error, Product}
 
   defmodule RequestOption do
     def get(%Request{opts: opts}) do
       opts
     end
+  end
+
+  test "it returns correct Response struct" do
+    result = {:ok, %HTTPoison.Response{
+      body: "{\"product\":{\"id\":123}}",
+      headers: [{"X-Shopify-Shop-Api-Call-Limit", "1/80"}],
+      status_code: 200
+    }}
+
+    assert {:ok, %Response{} = response} = HTTP.handle_response(result, %{"product" => %Product{}})
+
+    assert response.code == 200
+    assert response.data == %Product{id: 123}
+    assert response.headers == [{"X-Shopify-Shop-Api-Call-Limit", "1/80"}]
   end
 
   test "it handles httpoison errors" do


### PR DESCRIPTION
This allows the caller to access HTTP response headers. Some particularly useful headers:

- `Link` which is needed for cursor-based pagination (#83)
- `X-Shopify-Shop-Api-Call-Limit` which makes it possible to implement robust request throttling

Thanks!