### PR TITLE
Fix documentation for authentication in mock adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Lets say you have a test config file in `your_project/config/test.exs` and tests
 config :shopify, [
   shop_name: "test",
   api_key: "test-key",
-  password: "test-paswword",
+  password: "test-password",
   client_secret: "test-secret",
   client_adapter: Shopify.Adapters.Mock, # Use included Mock adapter
   fixtures_path: Path.expand("../test/fixtures/shopify", __DIR__) # Use fixures in this directory

--- a/lib/shopify/adapters/mock.ex
+++ b/lib/shopify/adapters/mock.ex
@@ -84,7 +84,7 @@ defmodule Shopify.Adapters.Mock do
 
   def basic_auth(request) do
     case URI.parse(request.full_url) do
-      %URI{userinfo: "test:test"} -> {:passed, request}
+      %URI{userinfo: "test-key:test-password"} -> {:passed, request}
       %URI{userinfo: _} -> {:failed, request}
     end
   end


### PR DESCRIPTION
Mock adapter was only accepting test as username and password. However documentation was directing to configure them differently. Fixed so that both are same now