### PR TITLE
Capture Poison 3.x case clause

### DIFF
--- a/lib/shopify/response.ex
+++ b/lib/shopify/response.ex
@@ -28,6 +28,7 @@ defmodule Shopify.Response do
       {:ok, %Shopify.OAuth{} = oauth} -> oauth
       {:ok, resource} -> parse_resource(resource)
       {:error, _} -> nil
+      {:error, _, _} -> nil # Poison 3.x bug
     end
   end
 


### PR DESCRIPTION
Resolves #95 

In Poison 3.x, [there is an error case](https://github.com/devinus/poison/issues/149) where it can return a 3-item tuple. This captures that error case so that projects using Poison 3.x can continue to work without CaseClauseErrors popping up.