### PR TITLE
missing cols for orders

### DIFF
--- a/lib/shopify/adapters/http.ex
+++ b/lib/shopify/adapters/http.ex
@@ -29,7 +29,10 @@ defmodule Shopify.Adapters.HTTP do
   end
 
   def handle_response({:ok, %HTTPoison.Response{} = resp}, resource) do
-    Shopify.Response.new(%{body: resp.body, code: resp.status_code, headers: resp.headers}, resource)
+    Shopify.Response.new(
+      %{body: resp.body, code: resp.status_code, headers: resp.headers},
+      resource
+    )
   end
 
   def handle_response({:error, %HTTPoison.Error{reason: reason}}, _resource) do

--- a/lib/shopify/resources/image.ex
+++ b/lib/shopify/resources/image.ex
@@ -25,7 +25,9 @@ defmodule Shopify.Image do
     :product_id,
     :src,
     :updated_at,
-    :variant_ids
+    :variant_ids,
+    :width,
+    :height
   ]
 
   @doc false

--- a/lib/shopify/resources/inventory_level.ex
+++ b/lib/shopify/resources/inventory_level.ex
@@ -134,5 +134,6 @@ defmodule Shopify.InventoryLevel do
   @doc false
   def all_url, do: @plural <> ".json"
 
-  defp unprocessable_entity(msg), do: Shopify.Response.new(%{body: msg, code: 422, headers: []}, empty_resource())
+  defp unprocessable_entity(msg),
+    do: Shopify.Response.new(%{body: msg, code: 422, headers: []}, empty_resource())
 end

--- a/lib/shopify/resources/order.ex
+++ b/lib/shopify/resources/order.ex
@@ -30,6 +30,9 @@ defmodule Shopify.Order do
   }
 
   defstruct [
+    :send_receipt,
+    :send_fulfillment_receipt,
+    :inventory_behaviour,
     :billing_address,
     :browser_ip,
     :buyer_accepts_marketing,

--- a/lib/shopify/resources/page.ex
+++ b/lib/shopify/resources/page.ex
@@ -26,7 +26,8 @@ defmodule Shopify.Page do
     :published_at,
     :template_suffix,
     :published,
-    :metafields
+    :metafields,
+    :collects
   ]
 
   @doc false

--- a/test/adapters/http_test.exs
+++ b/test/adapters/http_test.exs
@@ -10,13 +10,16 @@ defmodule Shopify.Adapters.HTTPTest do
   end
 
   test "it returns correct Response struct" do
-    result = {:ok, %HTTPoison.Response{
-      body: "{\"product\":{\"id\":123}}",
-      headers: [{"X-Shopify-Shop-Api-Call-Limit", "1/80"}],
-      status_code: 200
-    }}
+    result =
+      {:ok,
+       %HTTPoison.Response{
+         body: "{\"product\":{\"id\":123}}",
+         headers: [{"X-Shopify-Shop-Api-Call-Limit", "1/80"}],
+         status_code: 200
+       }}
 
-    assert {:ok, %Response{} = response} = HTTP.handle_response(result, %{"product" => %Product{}})
+    assert {:ok, %Response{} = response} =
+             HTTP.handle_response(result, %{"product" => %Product{}})
 
     assert response.code == 200
     assert response.data == %Product{id: 123}

--- a/test/shopify_payments/payout_test.exs
+++ b/test/shopify_payments/payout_test.exs
@@ -7,7 +7,14 @@ defmodule Shopify.ShopifyPayments.PayoutTest do
     assert {:ok, response} = Shopify.session() |> Payout.find(1)
     assert %Shopify.Response{} = response
     assert 200 == response.code
-    fixture = Fixture.load("../test/fixtures/shopify_payments/payouts/1.json", "payout", Payout.empty_resource())
+
+    fixture =
+      Fixture.load(
+        "../test/fixtures/shopify_payments/payouts/1.json",
+        "payout",
+        Payout.empty_resource()
+      )
+
     assert fixture == response.data
   end
 
@@ -15,7 +22,12 @@ defmodule Shopify.ShopifyPayments.PayoutTest do
     assert {:ok, response} = Shopify.session() |> Payout.all()
     assert %Shopify.Response{} = response
     assert 200 == response.code
-    fixture = Fixture.load("../test/fixtures/shopify_payments/payouts.json", "payouts", [Payout.empty_resource()])
+
+    fixture =
+      Fixture.load("../test/fixtures/shopify_payments/payouts.json", "payouts", [
+        Payout.empty_resource()
+      ])
+
     assert fixture == response.data
   end
 end


### PR DESCRIPTION
Missing default_inventory behaviour, send_receipt, and send_fulfillment: https://shopify.dev/docs/admin-api/rest/reference/orders/order#create-2021-01 